### PR TITLE
Refactor to remove global variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-global.ROOT_DIR = process.cwd();
-global.INSTALL_DIR = __dirname;
+const rootDir = process.cwd();
+const installDir = __dirname;
 const pkg = require('./package.json');
 const updateNotifier = require('update-notifier')({pkg});
 const c = require('chalk');
@@ -9,7 +9,9 @@ const i = require('inquirer');
 const fs = require("fs-extra");
 const jimp = require("jimp");
 var prog = require('progress-bar-formatter');
-require(__dirname + "/walkDir.js");
+const walkDirectory = require(__dirname + "/walkDir.js");
+
+const context = { rootDir, installDir, walkDirectory };
 
 if(updateNotifier.update){
     updateNotifier.notify({defer:false, isGlobal:true}); // display plz-update notification message
@@ -18,12 +20,12 @@ if(updateNotifier.update){
     main(); // up to date - start right away
 }
 function main(){
-    require(global.INSTALL_DIR + "/lib/splash_screen")(c).then(function () {
-        global.main_menu();
+    require(installDir + "/lib/splash_screen")(c).then(function () {
+        main_menu();
     });
 }
 
-global.main_menu = function() {
+function main_menu() {
     console.log('\x1Bc');
     i.prompt([{
         type: "list",
@@ -36,33 +38,33 @@ global.main_menu = function() {
         ]
     }]).then(function (result) {
         if (result.action.charAt(0) === '1') {
-            require(global.INSTALL_DIR + "/lib/get_image")(c, i,
+            require(installDir + "/lib/get_image")(c, i,
                 "Choose an image to test your settings on").then(function (test_img_path) {
-                require(global.INSTALL_DIR + "/lib/get_settings")(c, i).then(function (settings) {
+                require(installDir + "/lib/get_settings")(c, i).then(function (settings) {
                     console.log('\x1Bc');
                     console.log("\nProcessing image...");
                     var filename = /.*\/([^\/]*\.[^\.]*)$/.exec(test_img_path)[1];
-                    require(global.INSTALL_DIR + "/lib/process_image")(global.ROOT_DIR + test_img_path, settings, filename).then(function (amount_black_pixels) {
+                    require(installDir + "/lib/process_image")(context.rootDir, context.rootDir + test_img_path, settings, filename).then(function (amount_black_pixels) {
                         console.log(c.green("\nImage processed!"));
                         console.log("(" + amount_black_pixels + " dark pixels detected)");
-                        console.log("Output can be found in \"" + global.ROOT_DIR + test_img_path + "\"");
-                        setTimeout(global.main_menu, 4500);
+                        console.log("Output can be found in \"" + context.rootDir + test_img_path + "\"");
+                        setTimeout(main_menu, 4500);
                     });
                 });
             });
         } else if (result.action.charAt(0) === '2') {
-            require(global.INSTALL_DIR + "/lib/get_settings")(c, i).then(function (settings) {
-                require(global.INSTALL_DIR + "/lib/get_image")(c, i,
+            require(installDir + "/lib/get_settings")(c, i).then(function (settings) {
+                require(installDir + "/lib/get_image")(c, i,
                     "Choose a calibration-image containing a standard one-unit-large dark area for calibration").then(function (calib_img_path) {
                     console.log('\x1Bc');
                     console.log("\nCalculating calibration size...");
                     var filename = /.*\/([^\/]*\.[^\.]*)$/.exec(calib_img_path)[1];
-                    require(global.INSTALL_DIR + "/lib/process_image")(global.ROOT_DIR + calib_img_path, settings, filename).then(function (calibration_pixels) {
+                    require(installDir + "/lib/process_image")(context.rootDir, context.rootDir + calib_img_path, settings, filename).then(function (calibration_pixels) {
                         console.log(c.green("Calibration image processed! (" + calibration_pixels + " dark pixels detected)"));
                         setTimeout(function(){
                             console.log('\x1Bc');
                             console.log("The following files have been found and will now be processed: ");
-                            var files = global.walkDirectory(global.ROOT_DIR, "", 1).filter(function(t){return (/.*\.bmp/.test(t) || /.*\.jpg/.test(t) || /.*\.png/.test(t))});
+                            var files = context.walkDirectory(context.rootDir, "", 1).filter(function(t){return (/.*\.bmp/.test(t) || /.*\.jpg/.test(t) || /.*\.png/.test(t))});
                             console.log(files);
                             i.prompt([{
                                 type: "confirm",
@@ -88,7 +90,7 @@ global.main_menu = function() {
                                         return new Promise(function(resolve, reject){
                                             var file_path = files.shift();
                                             var filename = /.*\/([^\/]*\.[^\.]*)$/.exec(file_path)[1];
-                                            require(global.INSTALL_DIR + "/lib/process_image")(global.ROOT_DIR + file_path, settings, filename).then(function (dark_pixels) {
+                                            require(installDir + "/lib/process_image")(context.rootDir, context.rootDir + file_path, settings, filename).then(function (dark_pixels) {
                                                 arearesults[filename] = dark_pixels / calibration_pixels;
                                                 currentProgress++;
                                                 updateProgressBar(filename);
@@ -101,11 +103,11 @@ global.main_menu = function() {
                                     }
                                     processNextImg().then(function(){
                                         console.log(c.green("\n\n All files processed!"));
-                                        fs.writeJsonSync(global.ROOT_DIR + "/nowhitearea.json", arearesults);
-                                        setTimeout(global.main_menu, 5000);
+                                        fs.writeJsonSync(context.rootDir + "/nowhitearea.json", arearesults);
+                                        setTimeout(main_menu, 5000);
                                     });
                                 }else{
-                                    global.main_menu()
+                                    main_menu()
                                 }
                             })
                         }, 3500);
@@ -117,3 +119,4 @@ global.main_menu = function() {
         }
     });
 };
+

--- a/lib/get_image.js
+++ b/lib/get_image.js
@@ -1,6 +1,6 @@
-module.exports = function getImage(c, i, msg){
+module.exports = function getImage(c, i, msg, context){
     return new Promise(function(resolve, reject){
-        var files = global.walkDirectory(global.ROOT_DIR, "", 1);
+        var files = context.walkDirectory(context.rootDir, "", 1);
         files = files.filter(function(t){return (/.*\.bmp/.test(t) || /.*\.jpg/.test(t) || /.*\.png/.test(t))});
         if(files.length === 0){
             console.log(c(c.bold.red("\nERROR"), c.red(": No *.bmp *.png or *.jpeg images can be found in \"" + __dirname + "\"!")));

--- a/lib/process_image.js
+++ b/lib/process_image.js
@@ -1,6 +1,6 @@
 const jimp = require("jimp");
 
-module.exports = function(path, settings, filename){
+module.exports = function(rootDir, path, settings, filename){
     return new Promise(function(resolve, reject){
         jimp.read(path).then(function(img_jimp){
             var total_dark_pixels = 0;
@@ -34,7 +34,7 @@ module.exports = function(path, settings, filename){
 
                 img_jimp.setPixelColor(outputColor, x, y);
             });
-            img_jimp.write(global.ROOT_DIR + "/nonwhitearea_output/"  + filename, function(err){
+            img_jimp.write(rootDir + "/nonwhitearea_output/"  + filename, function(err){
                 if(err)
                     reject(err);
                 else

--- a/walkDir.js
+++ b/walkDir.js
@@ -1,11 +1,17 @@
 const fs = require('fs');
-global.walkDirectory = function(rootdir, subdir, depth) {
-    var results = [];
-    var list = fs.readdirSync(rootdir + subdir);
+
+function walkDirectory(rootdir, subdir, depth) {
+    let results = [];
+    const list = fs.readdirSync(rootdir + subdir);
     list.forEach(function(file) {
-        var stat = fs.statSync(rootdir + subdir + '/' + file);
-        if (stat && stat.isDirectory() && depth > 1) results = results.concat(walkDirectory(rootdir, subdir + '/' + file, depth-1));
-        else results.push(subdir + '/' + file)
+        const stat = fs.statSync(rootdir + subdir + '/' + file);
+        if (stat && stat.isDirectory() && depth > 1) {
+            results = results.concat(walkDirectory(rootdir, subdir + '/' + file, depth - 1));
+        } else {
+            results.push(subdir + '/' + file);
+        }
     });
-    return results
-};
+    return results;
+}
+
+module.exports = walkDirectory;


### PR DESCRIPTION
## Summary
- eliminate `global.*` variables and pass configuration context
- adjust helper modules to accept arguments instead of relying on globals
- export the directory walker instead of assigning to `global`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684829f4e10c832cb66870c1a4a501c1