### PR TITLE
Fix failing tests

### DIFF
--- a/lib/process_image.js
+++ b/lib/process_image.js
@@ -11,12 +11,12 @@ module.exports = function(rootDir, path, settings, filename){
                 var green = this.bitmap.data[ idx + 1 ];
                 var blue  = this.bitmap.data[ idx + 2 ];
 
-                if(x <= settings.ml){
+                if(x < settings.ml){
                     outputColor = jimp.rgbaToInt(0, 0, 200, 255);
                 }else if(x >= img_jimp.bitmap.width - settings.mr){
                     outputColor = jimp.rgbaToInt(0, 0, 200, 255);
                 }
-                if(y <= settings.mt){
+                if(y < settings.mt){
                     outputColor = jimp.rgbaToInt(0, 200, 0, 255);
                 }else if(y >= img_jimp.bitmap.height - settings.mb){
                     outputColor = jimp.rgbaToInt(0, 200, 0, 255);

--- a/test/process_image.test.js
+++ b/test/process_image.test.js
@@ -2,26 +2,26 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-function createFakeImage() {
-  const width = 1;
-  const height = 1;
-  const data = Buffer.from([100, 100, 100, 255]);
-  return {
-    bitmap: { width, height, data },
-    scan: function(sx, sy, w, h, cb) {
-      for (let y = 0; y < height; y++) {
-        for (let x = 0; x < width; x++) {
-          const idx = (width * y + x) * 4;
-          cb.call(this, x, y, idx);
-        }
-      }
-    },
-    setPixelColor() {},
-    write: function(p, cb) { fs.writeFileSync(p, ''); cb(); }
-  };
-}
-
 jest.mock('jimp', () => {
+  const fs = require('fs');
+  function createFakeImage() {
+    const width = 1;
+    const height = 1;
+    const data = Buffer.from([100, 100, 100, 255]);
+    return {
+      bitmap: { width, height, data },
+      scan: function(sx, sy, w, h, cb) {
+        for (let y = 0; y < height; y++) {
+          for (let x = 0; x < width; x++) {
+            const idx = (width * y + x) * 4;
+            cb.call(this, x, y, idx);
+          }
+        }
+      },
+      setPixelColor() {},
+      write: function(p, cb) { fs.writeFileSync(p, ''); cb(); }
+    };
+  }
   const fakeImg = createFakeImage();
   return {
     read: jest.fn(() => Promise.resolve(fakeImg)),
@@ -34,10 +34,9 @@ const processImage = require('../lib/process_image');
 describe('process_image', () => {
   test('counts dark pixels in image', async () => {
     const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'pimg-'));
-    global.ROOT_DIR = tmpdir;
     fs.mkdirSync(path.join(tmpdir, 'nonwhitearea_output'), { recursive: true });
     const settings = { ml: 0, mr: 0, mt: 0, mb: 0, minBright: 128 };
-    const count = await processImage('dummy', settings, 'out.png');
+    const count = await processImage(tmpdir, 'dummy', settings, 'out.png');
     expect(count).toBe(1);
     expect(fs.existsSync(path.join(tmpdir, 'nonwhitearea_output', 'out.png'))).toBe(true);
     fs.rmSync(tmpdir, { recursive: true, force: true });

--- a/test/walkDir.test.js
+++ b/test/walkDir.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-require('../walkDir');
+const walkDirectory = require('../walkDir');
 
 describe('walkDirectory', () => {
   let tmpDir;
@@ -19,12 +19,12 @@ describe('walkDirectory', () => {
   });
 
   test('depth 1 returns top level entries', () => {
-    const files = global.walkDirectory(tmpDir, '', 1).sort();
+    const files = walkDirectory(tmpDir, '', 1).sort();
     expect(files).toEqual(['/root.txt', '/sub'].sort());
   });
 
   test('depth 2 returns nested files', () => {
-    const files = global.walkDirectory(tmpDir, '', 2).sort();
+    const files = walkDirectory(tmpDir, '', 2).sort();
     expect(files).toEqual(['/root.txt', '/sub/subfile.txt'].sort());
   });
 });


### PR DESCRIPTION
## Summary
- remove outdated global usage in tests
- inline mocked image builder to satisfy Jest
- adjust margin comparisons in `process_image`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482eba5f2c832cbc93fb4e1a4b1366