### PR TITLE
Fix get_image context usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function main_menu() {
     }]).then(function (result) {
         if (result.action.charAt(0) === '1') {
             require(path.join(installDir, 'lib', 'get_image'))(c, i,
-                "Choose an image to test your settings on").then(function (test_img_path) {
+                "Choose an image to test your settings on", context).then(function (test_img_path) {
                 require(path.join(installDir, 'lib', 'get_settings'))(c, i).then(function (settings) {
                     console.log('\x1Bc');
                     console.log("\nProcessing image...");
@@ -56,7 +56,7 @@ function main_menu() {
         } else if (result.action.charAt(0) === '2') {
             require(path.join(installDir, 'lib', 'get_settings'))(c, i).then(function (settings) {
                 require(path.join(installDir, 'lib', 'get_image'))(c, i,
-                    "Choose a calibration-image containing a standard one-unit-large dark area for calibration").then(function (calib_img_path) {
+                    "Choose a calibration-image containing a standard one-unit-large dark area for calibration", context).then(function (calib_img_path) {
                     console.log('\x1Bc');
                     console.log("\nCalculating calibration size...");
                     var filename = /.*\/([^\/]*\.[^\.]*)$/.exec(calib_img_path)[1];

--- a/lib/get_image.js
+++ b/lib/get_image.js
@@ -3,7 +3,7 @@ module.exports = function getImage(c, i, msg, context){
         var files = context.walkDirectory(context.rootDir, "", 1);
         files = files.filter(function(t){return (/.*\.bmp/.test(t) || /.*\.jpg/.test(t) || /.*\.png/.test(t))});
         if(files.length === 0){
-            console.log(c(c.bold.red("\nERROR"), c.red(": No *.bmp *.png or *.jpeg images can be found in \"" + __dirname + "\"!")));
+            console.log(c(c.bold.red("\nERROR"), c.red(": No *.bmp *.png or *.jpeg images can be found in \"" + context.rootDir + "\"!")));
         }else{
             console.log('\x1Bc');
             i.prompt([{


### PR DESCRIPTION
## Summary
- pass `context` when calling `get_image`
- reference `context.rootDir` instead of `__dirname` in `get_image`

## Testing
- `npm test` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684835913ec0832c9401174414a222c0