### PR TITLE
Fix output folder creation

### DIFF
--- a/lib/process_image.js
+++ b/lib/process_image.js
@@ -1,5 +1,6 @@
 const jimp = require("jimp");
 const path = require('path');
+const fs = require('fs');
 
 module.exports = function(rootDir, imgPath, settings, filename){
     return new Promise(function(resolve, reject){
@@ -35,6 +36,7 @@ module.exports = function(rootDir, imgPath, settings, filename){
 
                 img_jimp.setPixelColor(outputColor, x, y);
             });
+            fs.mkdirSync(path.join(rootDir, 'nonwhitearea_output'), { recursive: true });
             img_jimp.write(path.join(rootDir, 'nonwhitearea_output', filename), function(err){
                 if(err)
                     reject(err);


### PR DESCRIPTION
## Summary
- create `nonwhitearea_output` automatically before writing files

## Testing
- `npm test` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684835a662c8832c8d29e8ee7d46c362