### PR TITLE
Fix Node tests and remove mocks

### DIFF
--- a/test/process_image.test.js
+++ b/test/process_image.test.js
@@ -3,44 +3,24 @@ const assert = require('node:assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-
-jest.mock('jimp', () => {
-  const fs = require('fs');
-  function createFakeImage() {
-    const width = 1;
-    const height = 1;
-    const data = Buffer.from([100, 100, 100, 255]);
-    return {
-      bitmap: { width, height, data },
-      scan: function(sx, sy, w, h, cb) {
-        for (let y = 0; y < height; y++) {
-          for (let x = 0; x < width; x++) {
-            const idx = (width * y + x) * 4;
-            cb.call(this, x, y, idx);
-          }
-        }
-      },
-      setPixelColor() {},
-      write: function(p, cb) { fs.writeFileSync(p, ''); cb(); }
-    };
-  }
-  const fakeImg = createFakeImage();
-  return {
-    read: jest.fn(() => Promise.resolve(fakeImg)),
-    rgbaToInt: () => 0
-  };
-});
+const Jimp = require('jimp');
 
 const processImage = require('../lib/process_image');
 
-describe('process_image', () => {
+test.describe('process_image', () => {
   test('counts dark pixels in image', async () => {
     const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'pimg-'));
     fs.mkdirSync(path.join(tmpdir, 'nonwhitearea_output'), { recursive: true });
+
+    const inputPath = path.join(tmpdir, 'in.png');
+    const img = new Jimp(1, 1, 0x000000ff);
+    await img.writeAsync(inputPath);
+
     const settings = { ml: 0, mr: 0, mt: 0, mb: 0, minBright: 128 };
-    const count = await processImage(tmpdir, 'dummy', settings, 'out.png');
-    expect(count).toBe(1);
-    expect(fs.existsSync(path.join(tmpdir, 'nonwhitearea_output', 'out.png'))).toBe(true);
+    const count = await processImage(tmpdir, inputPath, settings, 'out.png');
+    assert.strictEqual(count, 1);
+    assert.ok(fs.existsSync(path.join(tmpdir, 'nonwhitearea_output', 'out.png')));
+
     fs.rmSync(tmpdir, { recursive: true, force: true });
   });
 });

--- a/test/walkDir.test.js
+++ b/test/walkDir.test.js
@@ -6,33 +6,27 @@ const path = require('path');
 
 const walkDirectory = require('../walkDir');
 
-function setupTempDir() {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'walkdir-'));
-  fs.writeFileSync(path.join(tmpDir, 'root.txt'), 'root');
-  fs.mkdirSync(path.join(tmpDir, 'sub'));
-  fs.writeFileSync(path.join(tmpDir, 'sub', 'subfile.txt'), 'sub');
-  return tmpDir;
-}
+test.describe('walkDir', () => {
+  let tmpDir;
 
-  beforeEach(() => {
+  test.beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'walkdir-'));
     fs.writeFileSync(path.join(tmpDir, 'root.txt'), 'root');
     fs.mkdirSync(path.join(tmpDir, 'sub'));
     fs.writeFileSync(path.join(tmpDir, 'sub', 'subfile.txt'), 'sub');
   });
 
-  afterEach(() => {
+  test.afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test('depth 1 returns top level entries', () => {
     const files = walkDirectory(tmpDir, '', 1).sort();
-    expect(files).toEqual(['/root.txt', '/sub'].sort());
+    assert.deepStrictEqual(files, ['/root.txt', '/sub'].sort());
   });
 
   test('depth 2 returns nested files', () => {
     const files = walkDirectory(tmpDir, '', 2).sort();
-    expect(files).toEqual(['/root.txt', '/sub/subfile.txt'].sort());
+    assert.deepStrictEqual(files, ['/root.txt', '/sub/subfile.txt'].sort());
   });
 });
-


### PR DESCRIPTION
## Summary
- remove jest mocking and use real `Jimp` for `process_image` test
- add proper suite to `walkDir.test.js`
- swap `expect` for `assert`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684853d2f240832ca7a646e48a52aaf4